### PR TITLE
Add basic commenting support

### DIFF
--- a/src/main/kotlin/org/hnisula/cpp2plugin/Cpp2Commenter.kt
+++ b/src/main/kotlin/org/hnisula/cpp2plugin/Cpp2Commenter.kt
@@ -1,0 +1,16 @@
+package org.hnisula.cpp2plugin
+
+import com.intellij.lang.Commenter
+
+// TODO: Implement SelfManagingCommenter instead for better removal of block comments
+class Cpp2Commenter : Commenter {
+    override fun getLineCommentPrefix(): String = "//"
+
+    override fun getBlockCommentPrefix(): String = "/*"
+
+    override fun getBlockCommentSuffix(): String = "*/"
+
+    override fun getCommentedBlockCommentPrefix(): String? = null
+
+    override fun getCommentedBlockCommentSuffix(): String? = null
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -38,5 +38,6 @@
                 language="Cpp2"
                 implementationClass="org.hnisula.cpp2plugin.Cpp2ParserDefinition"
         />
+        <lang.commenter language="Cpp2" implementationClass="org.hnisula.cpp2plugin.Cpp2Commenter"/>
     </extensions>
 </idea-plugin>


### PR DESCRIPTION
IDE shortcuts for line and block comments now work. However, removing block comments when cursor is inside a block comment, by using the block comment shortcut does not work. This seems to require implementing `SelfManagingCommenter` instead of `Commenter`.

Closes #8 .